### PR TITLE
OpQueue: Remove goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/lytics/inflight
 
-go 1.17
+go 1.21
 
-require github.com/stretchr/testify v1.7.0
+require github.com/stretchr/testify v1.8.4
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,10 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
-github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/opqueue.go
+++ b/opqueue.go
@@ -112,7 +112,6 @@ func (q *OpQueue) Enqueue(id ID, op *Op) error {
 		return ErrQueueSaturatedWidth
 	}
 
-	// Q (2023-11) (mh): Why don't we signal here?
 	set.append(op)
 	return nil
 }

--- a/opqueue.go
+++ b/opqueue.go
@@ -2,20 +2,20 @@ package inflight
 
 import (
 	"container/list"
-	"context"
-	"fmt"
+	"errors"
 	"sync"
 )
 
 var (
 	// ErrQueueSaturatedDepth is the error returned when the queue has reached
 	// it's max queue depth
-	ErrQueueSaturatedDepth = fmt.Errorf("queue is saturated (depth)")
+	ErrQueueSaturatedDepth = errors.New("queue is saturated (depth)")
 
 	// ErrQueueSaturatedWidth is the error returned when a OpSet (aka a row) with
 	// in the queue has reached it's max width.  This happens when one submits
 	// many duplicate IDs.
-	ErrQueueSaturatedWidth = fmt.Errorf("queue is saturated (width)")
+	ErrQueueSaturatedWidth = errors.New("queue is saturated (width)")
+	ErrQueueClosed         = errors.New("queue closed")
 )
 
 // OpQueue is a thread-safe duplicate operation suppression queue, that combines
@@ -29,49 +29,41 @@ var (
 // It blocks on dequeue if the queue is empty, but returns an error if the
 // queue is full during enqueue.
 type OpQueue struct {
-	cond *sync.Cond
-	ctx  context.Context
-	can  context.CancelFunc
-
+	mu      sync.Mutex
+	cond    sync.Cond
 	depth   int
 	width   int
 	q       *list.List
 	entries map[ID]*OpSet
+	closed  bool
 }
 
 // NewOpQueue create a new OpQueue.
 func NewOpQueue(depth, width int) *OpQueue {
-	cond := sync.NewCond(&sync.Mutex{})
-	myctx, can := context.WithCancel(context.Background())
-	q := &OpQueue{
-		cond:    cond,
-		ctx:     myctx,
-		can:     can,
+	q := OpQueue{
 		depth:   depth,
 		width:   width,
 		q:       list.New(),
 		entries: map[ID]*OpSet{},
 	}
-	go func() {
-		<-myctx.Done()
-		q.cond.L.Lock()
-		defer q.cond.L.Unlock()
-		cond.Broadcast() // alert all dequeue calls that they should wake up and return.
-	}()
-	return q
+	q.cond.L = &q.mu
+	return &q
 }
 
 // Close releases resources associated with this callgroup, by canceling the context.
 // The owner of this OpQueue should either call Close or cancel the context, both are
 // equivalent.
 func (q *OpQueue) Close() {
-	q.can()
+	q.mu.Lock()
+	q.closed = true
+	q.mu.Unlock()
+	q.cond.Broadcast() // alert all dequeue calls that they should wake up and return.
 }
 
 // Len returns the number of uniq IDs in the queue, that is the depth of the queue.
 func (q *OpQueue) Len() int {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	return q.q.Len()
 }
 
@@ -82,9 +74,12 @@ func (q *OpQueue) Len() int {
 // Enqueue doesn't block if the queue if full, instead it returns a ErrQueueSaturated
 // error.
 func (q *OpQueue) Enqueue(id ID, op *Op) error {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
+	q.mu.Lock()
+	defer q.mu.Unlock()
 
+	if q.closed {
+		return ErrQueueClosed
+	}
 	if q.q.Len() >= q.depth {
 		return ErrQueueSaturatedDepth
 	}
@@ -111,11 +106,14 @@ func (q *OpQueue) Enqueue(id ID, op *Op) error {
 		// the condition lock until this method call returns, finishing
 		// its append of the new operation.
 		q.cond.Signal()
-	} else if len(set.Ops()) >= q.width {
-		return ErrQueueSaturatedWidth
-	} else {
-		set.append(op)
+		return nil
 	}
+	if len(set.Ops()) >= q.width {
+		return ErrQueueSaturatedWidth
+	}
+
+	// Q (2023-11) (mh): Why don't we signal here?
+	set.append(op)
 	return nil
 }
 
@@ -126,19 +124,17 @@ func (q *OpQueue) Enqueue(id ID, op *Op) error {
 // If the OpQueue is closed, then Dequeue will return false
 // for the second parameter.
 func (q *OpQueue) Dequeue() (*OpSet, bool) {
-	q.cond.L.Lock()
-	defer q.cond.L.Unlock()
+	q.mu.Lock()
+	defer q.mu.Unlock()
 
 	for {
 		if set, ok := q.dequeue(); ok {
 			return set, true
 		}
-
-		select {
-		case <-q.ctx.Done():
+		if q.closed {
 			return nil, false
-		default:
 		}
+
 		// release the lock and wait until signaled.  On awake we'll acquire the lock.
 		// After wait acquires the lock we have to recheck the wait condition,
 		// because it's possible that someone else

--- a/opqueue_test.go
+++ b/opqueue_test.go
@@ -200,11 +200,9 @@ func TestOpQueueFullWidth(t *testing.T) {
 		t.Fatalf("testcase timed out after 5 secs.")
 	})
 
-	found := 0
 	set1, open := opq.Dequeue()
 	assert.True(t, open)
 	assert.Equal(t, 10, len(set1.Ops()), " at loop:%v set1_len:%v", succuess, len(set1.Ops())) // max width is 10, so we should get 10 in the first batch
-	found += len(set1.Ops())
 
 	timer.Stop()
 }
@@ -256,7 +254,7 @@ func TestOpQueueForRaceDetection(t *testing.T) {
 				case ErrQueueSaturatedWidth:
 					widthErrorCnt.Incr()
 				default:
-					t.Fatalf("unexpected error: %v", err)
+					t.Errorf("unexpected error: %v", err)
 				}
 			}
 		}(w)


### PR DESCRIPTION
# Changes

* Remove the goroutine from OpQueue and use a closed status instead.
* Upgrade dependencies.
* Miscellaneous cleanup.