### PR TITLE
Add dedupequeue with ownership

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage.txt
 
 # vscode settings
 .vscode/settings.json
+.aider*

--- a/opset.go
+++ b/opset.go
@@ -16,6 +16,10 @@ func (os *OpSet) append(op *Op) {
 	os.set = append(os.set, op)
 }
 
+func (os *OpSet) Len() int {
+	return len(os.set)
+}
+
 // Ops get the list of ops in this set.
 func (os *OpSet) Ops() []*Op {
 	return os.set


### PR DESCRIPTION
Add a version of inflight that ensures only one copy of an item id is being processed at once.